### PR TITLE
Remove log_level prompt from setup

### DIFF
--- a/src/nexus/server/installation/setup.py
+++ b/src/nexus/server/installation/setup.py
@@ -232,16 +232,11 @@ def create_interactive_config(default_config: config.NexusServerConfig) -> confi
 
     node_name = input(f"Node name [default: {default_config.node_name}]: ").strip() or default_config.node_name
 
-    log_level = (
-        input(f"Log level (debug/info/warning/error) [default: {default_config.log_level}]: ").strip()
-        or default_config.log_level
-    )
-
     return config.NexusServerConfig(
         server_dir=default_config.server_dir,
         port=port,
         node_name=node_name,
-        log_level=log_level,
+        log_level=default_config.log_level,
     )
 
 


### PR DESCRIPTION
## Summary
- Removes the log_level prompt during interactive setup
- Keeps log_level in config but uses the default value instead
- Simplifies the setup experience

## Test plan
- Test `nx setup` and verify the log_level field is not prompted
- Confirm the default log_level is properly set and used

🤖 Generated with [Claude Code](https://claude.ai/code)