### PR TITLE
Show number of GPUs requested in nx queue

### DIFF
--- a/src/nexus/cli/jobs.py
+++ b/src/nexus/cli/jobs.py
@@ -316,13 +316,19 @@ def show_queue() -> None:
         total_jobs = len(jobs)
         for idx, job in enumerate(reversed(jobs), 1):
             created_time = utils.format_timestamp(job.get("created_at"))
-            priority_str = (
-                f" (Priority: {colored(str(job.get('priority', 0)), 'cyan')})" if job.get("priority", 0) != 0 else ""
-            )
+            
+            # Get priority and number of GPUs requested
+            priority = job.get('priority', 0)
+            num_gpus = job.get('num_gpus', 1)
+            
+            # Build info strings conditionally
+            priority_str = f" (Priority: {colored(str(priority), 'cyan')})" if priority != 0 else ""
+            gpu_str = f" (GPUs: {colored(str(num_gpus), 'cyan')})" if num_gpus > 1 else ""
+            
             print(
                 f"{total_jobs - idx + 1}. {colored(job['id'], 'magenta')} - "
                 f"{colored(job['command'], 'white')} "
-                f"(Added: {colored(created_time, 'cyan')}){priority_str}"
+                f"(Added: {colored(created_time, 'cyan')}){priority_str}{gpu_str}"
             )
 
         print(f"\n{colored('Total queued jobs:', 'blue', attrs=['bold'])} {colored(str(total_jobs), 'cyan')}")
@@ -1048,8 +1054,12 @@ def print_status() -> None:
                 runtime = utils.calculate_runtime(job)
                 runtime_str = utils.format_runtime(runtime)
                 start_time = utils.format_timestamp(job.get("started_at"))
+                
+                # Get number of GPUs used by the job
+                job_gpu_count = job.get('num_gpus', 1)
+                gpu_count_str = f" ({job_gpu_count} GPUs)" if job_gpu_count > 1 else ""
 
-                print(f"{gpu_info}{colored(job_id, 'magenta')}")
+                print(f"{gpu_info}{colored(job_id, 'magenta')}{gpu_count_str}")
                 print(f"  Command: {colored(job.get('command', ''), 'white', attrs=['bold'])}")
                 print(f"  Time: {colored(runtime_str, 'cyan')} (Started: {colored(start_time, 'cyan')})")
                 if job.get("wandb_url"):

--- a/src/nexus/cli/utils.py
+++ b/src/nexus/cli/utils.py
@@ -165,15 +165,25 @@ def confirm_action(action_description: str, bypass: bool = False) -> bool:
         return True
 
     options = f"[{colored('y', 'green')}/{colored('N', 'red')}]"
-    response = input(f"\n{colored('?', 'blue', attrs=['bold'])} {action_description} {options} [press ENTER for {colored('NO', 'red')}]: ").lower().strip()
+    response = (
+        input(
+            f"\n{colored('?', 'blue', attrs=['bold'])} {action_description} {options} [press ENTER for {colored('NO', 'red')}]: "
+        )
+        .lower()
+        .strip()
+    )
     print()  # newline
     return response == "y"
 
 
 def ask_yes_no(question: str, default: bool = True) -> bool:
     default_text = "YES" if default else "NO"
-    options = f"[{colored('y', 'green')}/{colored('n', 'red')}]" 
-    default_prompt = f"[press ENTER for {colored(default_text, 'cyan')}, type {colored('n', 'red')} for no]" if default else f"[press ENTER for {colored(default_text, 'cyan')}, type {colored('y', 'green')} for yes]"
+    options = f"[{colored('y', 'green')}/{colored('n', 'red')}]"
+    default_prompt = (
+        f"[press ENTER for {colored(default_text, 'cyan')}, type {colored('n', 'red')} for no]"
+        if default
+        else f"[press ENTER for {colored(default_text, 'cyan')}, type {colored('y', 'green')} for yes]"
+    )
     prompt = f"{colored('?', 'blue', attrs=['bold'])} {question} {options} {default_prompt}: "
 
     while True:

--- a/src/nexus/server/api/app.py
+++ b/src/nexus/server/api/app.py
@@ -76,7 +76,8 @@ def create_app(ctx: context.NexusServerContext) -> fa.FastAPI:
     @contextlib.asynccontextmanager
     async def lifespan(app: fa.FastAPI):
         logger.info("Scheduler starting")
-        scheduler_task = asyncio.create_task(scheduler.scheduler_loop(ctx=app.state.ctx))
+        coro = scheduler.scheduler_loop(ctx=app.state.ctx)
+        scheduler_task = asyncio.create_task(coro)
         try:
             yield
         finally:

--- a/src/nexus/server/api/scheduler.py
+++ b/src/nexus/server/api/scheduler.py
@@ -1,8 +1,6 @@
 import asyncio
 import dataclasses as dc
 import datetime as dt
-import time
-from datetime import datetime, timedelta
 
 from nexus.server.core import context, db, job
 from nexus.server.external import gpu, notifications, wandb_finder, system

--- a/src/nexus/server/api/scheduler.py
+++ b/src/nexus/server/api/scheduler.py
@@ -2,7 +2,7 @@ import asyncio
 import dataclasses as dc
 import datetime as dt
 
-from nexus.server.core import context, db, job
+from nexus.server.core import context, db, job, exceptions as exc
 from nexus.server.external import gpu, notifications, wandb_finder, system
 from nexus.server.utils import format, logger
 
@@ -132,15 +132,15 @@ async def start_queued_jobs(ctx: context.NexusServerContext) -> None:
     logger.info(f"Processed jobs from queue; remaining queued jobs: {remaining}")
 
 
-@db.handle_exception_async(Exception, message="Health check encountered an error", reraise=False)
-async def check_system_health():
+@exc.handle_exception_async(Exception, message="Health check encountered an error", reraise=False)
+async def check_system_health() -> None:
     health_result = system.check_health(force_refresh=False)
     if health_result.status == "unhealthy":
         logger.warning(f"System health is UNHEALTHY: score {health_result.score}")
 
 
-@db.handle_exception_async(Exception, message="Scheduler encountered an error", reraise=False)
-async def scheduler_loop(ctx: context.NexusServerContext):
+@exc.handle_exception_async(Exception, message="Scheduler encountered an error", reraise=False)
+async def scheduler_loop(ctx: context.NexusServerContext) -> None:
     while True:
         await update_running_jobs(ctx=ctx)
         await update_wandb_urls(ctx=ctx)

--- a/src/nexus/server/core/exceptions.py
+++ b/src/nexus/server/core/exceptions.py
@@ -127,14 +127,21 @@ def handle_exception(
     return decorator
 
 
+T_co = tp.TypeVar("T_co", covariant=True)
+
+
 def handle_exception_async(
     source_exception: type[Exception],
     target_exception: type[NexusServerError] | None = None,
     message: str = "An error occurred",
     reraise: bool = True,
     default_return: tp.Any = None,
-) -> abc.Callable[[abc.Callable[P, tp.Awaitable[T]]], abc.Callable[P, tp.Awaitable[T]]]:
-    def decorator(func: abc.Callable[P, tp.Awaitable[T]]) -> abc.Callable[P, tp.Awaitable[T]]:
+) -> abc.Callable[
+    [abc.Callable[P, abc.Coroutine[tp.Any, tp.Any, T]]], abc.Callable[P, abc.Coroutine[tp.Any, tp.Any, T]]
+]:
+    def decorator(
+        func: abc.Callable[P, abc.Coroutine[tp.Any, tp.Any, T]],
+    ) -> abc.Callable[P, abc.Coroutine[tp.Any, tp.Any, T]]:
         @functools.wraps(func)
         async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             try:

--- a/src/nexus/server/external/system.py
+++ b/src/nexus/server/external/system.py
@@ -196,5 +196,5 @@ def check_health(force_refresh: bool = False) -> HealthCheckResult:
             del _cache["network_speed"]
         if "system_stats" in _cache:
             del _cache["system_stats"]
-    
+
     return _get_cached(key="health_result", default_factory=_calculate_health_result, ttl=timedelta(minutes=5))


### PR DESCRIPTION
## Summary
- Display the number of GPUs requested in the `nx queue` output
- Only show GPU count when more than 1 GPU is requested
- Also show GPU count for running jobs in the `nx status` command output
- Improve job details visibility in command line interface

## Test plan
- Run `nx queue` and verify jobs with multiple GPUs show the GPU count
- Check `nx status` to see GPU counts for running jobs
- Verify single-GPU jobs don't unnecessarily show a GPU count

🤖 Generated with [Claude Code](https://claude.ai/code)