### PR TITLE
Put Nexus job ID in tmpdir name

### DIFF
--- a/src/nexus/server/core/job.py
+++ b/src/nexus/server/core/job.py
@@ -249,7 +249,8 @@ def create_job(
 
 @exc.handle_exception_async(Exception, exc.JobError, message="Failed to start job")
 async def async_start_job(job: schemas.Job, gpu_idxs: list[int], server_dir: pl.Path | None) -> schemas.Job:
-    job_dir = pl.Path(tempfile.mkdtemp())
+    # Create a temporary directory with job ID in the name
+    job_dir = pl.Path(tempfile.mkdtemp(prefix=f"nexus-job-{job.id}-"))
     job_dir.mkdir(parents=True, exist_ok=True)
     job = dc.replace(job, dir=job_dir)
 

--- a/src/nexus/server/core/job.py
+++ b/src/nexus/server/core/job.py
@@ -249,7 +249,6 @@ def create_job(
 
 @exc.handle_exception_async(Exception, exc.JobError, message="Failed to start job")
 async def async_start_job(job: schemas.Job, gpu_idxs: list[int], server_dir: pl.Path | None) -> schemas.Job:
-    # Create a temporary directory with job ID in the name
     job_dir = pl.Path(tempfile.mkdtemp(prefix=f"nexus-job-{job.id}-"))
     job_dir.mkdir(parents=True, exist_ok=True)
     job = dc.replace(job, dir=job_dir)


### PR DESCRIPTION
## Summary
- Include the job ID in the temporary directory name created for each job
- Makes it easier to identify job directories in the filesystem
- Improves debugging by linking the temporary directory directly to a specific job ID

🤖 Generated with [Claude Code](https://claude.ai/code)