### PR TITLE
Fix API hanging when killing jobs with large logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 - [ ] Display memory usage in `nx health`
 - [ ] Support `{RANDINT}` syntax in commands
-- [ ] Put git token authentication and cloning stuff inside job script so that we get logs
 - [ ] Command autocomplete
 - [ ] Fix `wandb` search fallback
 
@@ -16,7 +15,6 @@
 - [ ] Git: make tagging optional
 - [ ] Gracefully skip pushing tag if repo isn't owned
 - [ ] Bug: `nx remove` repeats jobs multiple times
-- [ ] Kill job responsiveness: reduce lag when killing/refreshing
 - [ ] Support CPU-only jobs
 - [ ] Track per-job resource allocation in metadata
 - [ ] Documentation

--- a/src/nexus/server/core/job.py
+++ b/src/nexus/server/core/job.py
@@ -342,7 +342,7 @@ async def async_get_job_logs(job_dir: pl.Path | None, last_n_lines: int | None =
     if not logs.exists():
         return None
 
-    return _read_log_file(logs, last_n_lines)
+    return await asyncio.to_thread(_read_log_file, logs, last_n_lines)
 
 
 @exc.handle_exception(subprocess.SubprocessError, exc.JobError, message="Failed to kill job processes")


### PR DESCRIPTION
## Summary
- Fix API hanging when killing jobs with large log files by moving blocking file I/O to a thread
- Offload _read_log_file operation to asyncio.to_thread to keep event loop responsive

## Test plan
- Verify API responsiveness when killing jobs with large log files
- Test with concurrent API requests while killing a job

🤖 Generated with [Claude Code](https://claude.ai/code)