### PR TITLE
Fix memlock limit for InfiniBand in systemd service

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nexusai"
-version = "0.4.16"
+version = "0.4.17"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/nexus/server/installation/systemd.py
+++ b/src/nexus/server/installation/systemd.py
@@ -15,6 +15,7 @@ KillMode=process
 Restart=on-failure
 RestartSec=5
 Environment=PYTHONUNBUFFERED=1
+LimitMEMLOCK=infinity
 """
 
 INSTALL_SECTION = """[Install]


### PR DESCRIPTION
## Summary
- Added `LimitMEMLOCK=infinity` to the systemd service configuration
- Incremented version to 0.4.17

## Problem
The systemd service was running with default memory lock limits, which caused InfiniBand operations to fail with errors like:
```
ibv_create_cq: Resource temporarily unavailable
```

## Solution
By adding `LimitMEMLOCK=infinity` to the systemd service configuration, we ensure that the nexus-server process and all jobs it spawns have unlimited memory lock limits, matching the behavior of manual runs.

## Test plan
- [ ] Install the updated systemd service file
- [ ] Restart the nexus-server service
- [ ] Run a job that uses InfiniBand and verify it no longer fails with memlock errors

🤖 Generated with [Claude Code](https://claude.ai/code)