### PR TITLE
Increase artifact size limit to 50MB

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nexusai"
-version = "0.4.21"
+version = "0.4.22"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/nexus/server/api/router.py
+++ b/src/nexus/server/api/router.py
@@ -71,7 +71,7 @@ async def upload_artifact(request: fa.Request, ctx: context.NexusServerContext =
     if not raw:
         raise exc.InvalidRequestError("Empty artifact upload")
 
-    max_size_mb = 20
+    max_size_mb = 50
     max_size_bytes = max_size_mb * 1024 * 1024
     if len(raw) > max_size_bytes:
         raise exc.InvalidRequestError(f"Artifact exceeds maximum size of {max_size_mb} MB")

--- a/tests/server/test_api.py
+++ b/tests/server/test_api.py
@@ -38,9 +38,9 @@ def app_client() -> Iterator[TestClient]:
 
 
 def test_artifact_size_limit(app_client):
-    max_size_mb = 20
+    max_size_mb = 50
 
-    # Create a test file that exceeds the 20 MB limit
+    # Create a test file that exceeds the 50 MB limit
     size_bytes = (max_size_mb + 1) * 1024 * 1024
     data = os.urandom(size_bytes)
 

--- a/uv.lock
+++ b/uv.lock
@@ -601,7 +601,7 @@ wheels = [
 
 [[package]]
 name = "nexusai"
-version = "0.4.21"
+version = "0.4.22"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Increased maximum artifact upload size from 20MB to 50MB
- Updated version to 0.4.22
- Updated test to verify new 50MB limit
- Ran `uv sync` to update lock file

## Test plan
- [x] Updated `test_artifact_size_limit` to test 50MB limit
- [x] Verified test passes with new limit
- [x] Ran `uv sync` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)